### PR TITLE
auto-logout on session expiry and refresh collections

### DIFF
--- a/src/app/components/AppNavbar.jsx
+++ b/src/app/components/AppNavbar.jsx
@@ -53,11 +53,34 @@ export default function AppNavbar({ logoutButtonSize = 'sm' }) {
     try {
       const is = localStorage.getItem('auth:isLoggedin');
       if (is === '1') {
-        dispatch(loginAction());
-        const c = localStorage.getItem('auth:country');
-        if (c) dispatch(updateCountry(c)); 
-        const t = localStorage.getItem('auth:token'); 
-        if (t) dispatch(updateToken(t));
+        const t = localStorage.getItem('auth:token');
+        // Check JWT expiry before restoring auth state
+        let tokenExpired = true;
+        if (t) {
+          try {
+            const payload = JSON.parse(atob(t.split('.')[1]));
+            tokenExpired = !payload.exp || payload.exp * 1000 < Date.now();
+          } catch {
+            tokenExpired = true;
+          }
+        }
+        // Prefer the explicit session expiry timestamp stored at login time
+        const storedExpiry = parseInt(localStorage.getItem('auth:sessionExpiry') || '0', 10);
+        const sessionExpired = storedExpiry ? Date.now() > storedExpiry : tokenExpired;
+
+        if (sessionExpired) {
+          // Session has expired – clear persisted auth so user is shown as logged out
+          localStorage.removeItem('auth:isLoggedin');
+          localStorage.removeItem('auth:country');
+          localStorage.removeItem('auth:token');
+          localStorage.removeItem('auth:sessionExpiry');
+          localStorage.removeItem('selectedRegion');
+        } else {
+          dispatch(loginAction());
+          const c = localStorage.getItem('auth:country');
+          if (c) dispatch(updateCountry(c));
+          dispatch(updateToken(t));
+        }
       }
     } catch {}
 
@@ -92,6 +115,33 @@ export default function AppNavbar({ logoutButtonSize = 'sm' }) {
     }
   }, [dark, mounted]);
 
+  // Continuously watch for token expiry while logged in
+  useEffect(() => {
+    if (!isLoggedin) return;
+
+    const checkExpiry = () => {
+      try {
+        const expiry = parseInt(localStorage.getItem('auth:sessionExpiry') || '0', 10);
+        if (!expiry || Date.now() > expiry) {
+          handleLogout();
+        }
+      } catch {
+        handleLogout();
+      }
+    };
+
+    // Check every 30 seconds
+    const interval = setInterval(checkExpiry, 30_000);
+    // Also check immediately when the tab becomes visible again
+    const onVisible = () => { if (document.visibilityState === 'visible') checkExpiry(); };
+    document.addEventListener('visibilitychange', onVisible);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [isLoggedin]);
+
   // Close modal on successful login
   useEffect(() => {
     if (loginState && loginState.success) {
@@ -116,6 +166,9 @@ export default function AppNavbar({ logoutButtonSize = 'sm' }) {
         }
         if (loginState.token) { 
           localStorage.setItem('auth:token', loginState.token); 
+        }
+        if (loginState.sessionExpiry) {
+          localStorage.setItem('auth:sessionExpiry', String(loginState.sessionExpiry));
         }
       } catch {}
     }
@@ -180,6 +233,7 @@ export default function AppNavbar({ logoutButtonSize = 'sm' }) {
       localStorage.removeItem('auth:isLoggedin');
       localStorage.removeItem('auth:country');
       localStorage.removeItem('auth:token');
+      localStorage.removeItem('auth:sessionExpiry');
     } catch {}
   };
 

--- a/src/app/lib/session.ts
+++ b/src/app/lib/session.ts
@@ -16,9 +16,14 @@ const resolveKey = () => {
 };
 const encodedKey = new TextEncoder().encode(resolveKey());
 
+
+export const SESSION_DURATION_MS = 24 * 60 * 60 * 1000; // 1 minute (use 1 * 60 * 1000 1minute)
+
 export async function createSession(countryId: string, userId: string) {
-  // const expiresAt = new Date(Date.now() + 23 * 60 * 60 * 1000);
-  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); 
+  
+  // const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  
+  const expiresAt = new Date(Date.now() + SESSION_DURATION_MS);
   const session = await encrypt({ countryId, userId, expiresAt });
   const cookieStore = await cookies();
   cookieStore.set("session", session, {
@@ -43,7 +48,8 @@ export async function encrypt(payload: SessionPayload) {
   return new SignJWT(payload)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
-    .setExpirationTime("7d")
+    // Previous setting: .setExpirationTime("7d")
+    .setExpirationTime(Math.floor(Date.now() / 1000) + Math.floor(SESSION_DURATION_MS / 1000))
     .sign(encodedKey);
 }
 

--- a/src/app/login/action.ts
+++ b/src/app/login/action.ts
@@ -2,7 +2,7 @@
 "use server";
 
 import { z } from "zod";
-import { createSession, deleteSession } from "@/app/lib/session";
+import { createSession, deleteSession, SESSION_DURATION_MS } from "@/app/lib/session";
 import { get_url } from '@/app/components/urls';
 
 // Define the login form schema
@@ -19,6 +19,7 @@ interface PrevState {
   };
   success?: boolean;
   message?: string; // Add a message field for API errors
+  sessionExpiry?: number; // Unix ms timestamp when the session expires
 }
 
 export async function login(prevState: PrevState, formData: FormData) {
@@ -94,7 +95,7 @@ export async function login(prevState: PrevState, formData: FormData) {
     await createSession(country_idx, access);
 
     // Return a success flag to update Redux state on the client
-    return { success: true, countryId: country_idx, token: access } as PrevState;
+    return { success: true, countryId: country_idx, token: access, sessionExpiry: Date.now() + SESSION_DURATION_MS } as PrevState;
   } catch (error) {
     console.error("API request failed:", error);
     return {


### PR DESCRIPTION
- Add SESSION_DURATION_MS constant to session.ts
- Return sessionExpiry timestamp from login action
- Store auth:sessionExpiry in localStorage on login
- Check sessionExpiry (not API bearer token) in AppNavbar expiry watcher
- Poll every 30s and on tab visibility change to auto-logout when expired
- Clear auth state and localStorage on expiry so collections re-fetches public-only cards